### PR TITLE
fix dashboard pages header spacing

### DIFF
--- a/pages/dashboard/settings.vue
+++ b/pages/dashboard/settings.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-container class="pa-0 d-flex align-center justify-space-between">
-      <p class="headline py-5 ma-0 mr-5">
+      <p class="headline py-5 ma-0 mr-3">
         حساب کاربری
       </p>
       <div>

--- a/pages/dashboard/submissions.vue
+++ b/pages/dashboard/submissions.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-container class="pa-0 d-flex align-center justify-space-between">
-      <p class="headline py-5 ma-0">
+      <p class="headline py-5 ma-0 mr-3">
         ارسال کد
       </p>
       <!--      <SectionHeader :title="`ارسال کد`" />-->
@@ -32,7 +32,7 @@
 
       <!--    <div class="d-flex align-center justify-space-between ma-5">-->
       <!--      <SectionHeader :title="`تاریخچه ارسال ها`" :icon="`mdi-history`"/>-->
-      <div class="headline py-5 ma-0">
+      <div class="headline py-5 ma-0 mr-3">
         <v-icon color="">"mdi-history"</v-icon>
         <div v-if="tabs === 1">
           تاریخچه ارسال ها

--- a/pages/dashboard/team.vue
+++ b/pages/dashboard/team.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-container class="pa-0 d-flex align-center justify-space-between">
-      <p class="headline py-5 ma-0">
+      <p class="headline py-5 ma-0 mr-3">
         تیم
       </p>
       <div>

--- a/pages/dashboard/ticket/index.vue
+++ b/pages/dashboard/ticket/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-container class="pa-0 d-flex align-center justify-space-between">
-      <p class="headline py-5 ma-0">
+      <p class="headline py-5 ma-0 mr-3">
         تیکت
       </p>
       <div>


### PR DESCRIPTION
- add `mr-3` to these page headlines in order to fix the headline spacing issue based on this change:
https://github.com/SharifAIChallenge/AIC22-Frontend/blob/master/components/doc/Tree.vue#L5
  - `pages/dashboard/submissions.vue`
  - `pages/dashboard/team.vue`
  - `pages/dashboard/ticket/index.vue`
- change `mr-5` to `mr-3` in `settings.vue` to coordinate with other pages

---
![image](https://user-images.githubusercontent.com/16350906/181523594-4f463eeb-d32c-4a6d-9563-7689c843173f.png)