### PR TITLE
update `TeamInvitationAndHistory.vue`

### DIFF
--- a/components/dashboard/team/TeamInvitationAndHistory.vue
+++ b/components/dashboard/team/TeamInvitationAndHistory.vue
@@ -108,18 +108,20 @@
                   class="rounded-circle"
                   src="~/assets/images/avatar-sample.svg" alt="">
             </div>
-            <div class="text-center">
+            <div class="text-center" style="margin-top: -4rem;">
               <p v-if="dialog_item">
                 {{ dialog_item.user.profile.firstname_fa }} {{ dialog_item.user.profile.lastname_fa }}
               </p>
-              <div
-              v-if="dialog_item && dialog_item.user.profile.programming_languages && dialog_item.user.profile.programming_languages.length > 0"
-              >
-                <v-chip
-                    v-for="(lang,index) in dialog_item.user.profile.programming_languages" :key="index"
-                >
-                  {{ lang }}
-                </v-chip>
+            </div>
+            <div>
+              زبان های برنامه نویسی
+              <ul class="pr-4" v-if="dialog_item && dialog_item.user.profile.programming_languages && dialog_item.user.profile.programming_languages.length > 0">
+                <li v-for="(lang,index) in dialog_item.user.profile.programming_languages" :key="index">
+                  {{ lang.programming_language_title }}
+                </li>
+              </ul>
+              <div v-else>
+                -ثبت نشده است !-
               </div>
             </div>
           </v-card-text>


### PR DESCRIPTION
- fix profile name spacing in member dialog based on this change:
https://github.com/SharifAIChallenge/AIC22-Frontend/blob/master/components/dashboard/team/MyTeam.vue#L113
- update "programming_language_title" in member dialog based on similar usages on other pages:
https://github.com/SharifAIChallenge/AIC22-Frontend/blob/master/components/dashboard/team/MyTeam.vue#L123-L133

---
| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/16350906/181589507-86eca9a1-71a0-48ba-9686-17c9531dd47e.png) | ![image](https://user-images.githubusercontent.com/16350906/181589098-1c36509e-4922-4492-97a8-8f2e86314e78.png)  |